### PR TITLE
Update KordEx and Kotlin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
-kotlin = "2.0.20-Beta1"
-kordex = "2.0.0-20240818.103627-5"
+kotlin = "2.0.20-RC2"
+kordex = "2.1.0-20240820.102632-1"
 git-hooks = "0.0.2"
 licenser = "0.6.1"
 bin-compat = "0.15.0-Beta.3"


### PR DESCRIPTION
This PR makes the following changes:

- Update Kotlin to ``2.0.20-RC2`` (which is now what KordEx targets)
- Update KordEx to the current ``2.1.0`` snapshot build (which Reposilite shouldn't delete going forward)

This will need to be merged before I can (finally) get Lilybot's update PR done